### PR TITLE
Patch branding colors before upstream release

### DIFF
--- a/126cd8cbb428b8eb54311f880a3ae0bcbaf852a5.patch
+++ b/126cd8cbb428b8eb54311f880a3ae0bcbaf852a5.patch
@@ -1,0 +1,25 @@
+From 126cd8cbb428b8eb54311f880a3ae0bcbaf852a5 Mon Sep 17 00:00:00 2001
+From: Ranieri Althoff <1993083+ranisalt@users.noreply.github.com>
+Date: Tue, 27 May 2025 17:49:12 +0200
+Subject: [PATCH] Add branding colors to metainfo (#1121)
+
+---
+ misc/com.rioterm.Rio.metainfo.xml | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/misc/com.rioterm.Rio.metainfo.xml b/misc/com.rioterm.Rio.metainfo.xml
+index eac8339c5c..260d60247f 100644
+--- a/misc/com.rioterm.Rio.metainfo.xml
++++ b/misc/com.rioterm.Rio.metainfo.xml
+@@ -12,6 +12,11 @@
+     <p>Rio is open source and available for Windows, macOS, and Linux.</p>
+   </description>
+ 
++  <branding>
++    <color type="primary" scheme_preference="light">#b9a5d3</color>
++    <color type="primary" scheme_preference="dark">#2c1e3e</color>
++  </branding>
++
+   <project_license>MIT</project_license>
+   <metadata_license>CC0-1.0</metadata_license>
+ 

--- a/com.rioterm.Rio.yml
+++ b/com.rioterm.Rio.yml
@@ -50,4 +50,7 @@ modules:
       - type: patch
         path: 872bc039d2c4339b6a8a1968f2f83fde46066619.patch
 
+      - type: patch
+        path: 126cd8cbb428b8eb54311f880a3ae0bcbaf852a5.patch
+
       - generated-sources.json


### PR DESCRIPTION
Cherry picking commit that adds branding colors used by Flathub before it lands in a release.